### PR TITLE
chore(release): bump version to v0.2.4

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auranova-web",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auranova-web",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.12",
         "@radix-ui/react-alert-dialog": "1.1.15",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auranova-web",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
### ℹ️ Contexto
Este PR **solo** actualiza la versión del paquete a `v0.2.4`. No incluye cambios funcionales.

### ✨ Cambios incluidos en v0.2.4 (mergeados previamente)
- Login clásico (email+password) con Supabase.
- Routing multi-tenant `/t/:slug`.
- Guards de sesión mínimos con `<RequireRole>` (viewer/admin).
- Vistas `TenantAdmin` & `TenantLeads` por tenant.
- Redirecciones legacy → multi-tenant: `/admin`, `/leads`.

### ✅ CI
- Lint, Typecheck, Tests y Build en verde.
- Gitleaks OK.
- SQL/RLS OK.

### 🔍 Alcance del PR
- `package.json`
- `package-lock.json`

> Objetivo: alinear el número de versión del paquete con el tag `v0.2.4`.